### PR TITLE
Updated bluebird to version 2.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/ghaiklor/sails-service-sms#readme",
   "dependencies": {
-    "bluebird": "2.10.1",
+    "bluebird": "2.10.2",
     "lodash": "3.10.1",
     "twilio": "2.4.0"
   },


### PR DESCRIPTION
:rocket:

bluebird just published version 2.10.2, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
[GitHub Release](https://github.com/petkaantonov/bluebird/releases/tag/v2.10.2)

Features:

 - `.timeout()` now takes a custom error object as second argument

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>